### PR TITLE
Update manuf.py

### DIFF
--- a/manuf/manuf.py
+++ b/manuf/manuf.py
@@ -58,6 +58,7 @@ class MacParser(object):
 
     """
     MANUF_URL = "https://code.wireshark.org/review/gitweb?p=wireshark.git;a=blob_plain;f=manuf"
+    WFA_URL = "https://code.wireshark.org/review/gitweb?p=wireshark.git;a=blob_plain;f=wka"                                                                                           
 
     def  __init__(self, manuf_name="manuf", update=False):
         self._manuf_name = manuf_name
@@ -114,7 +115,7 @@ class MacParser(object):
 
         manuf_file.close()
 
-    def update(self, manuf_url=None, manuf_name=None, refresh=True):
+    def update(self, manuf_url=None, wfa_url=None, manuf_name=None, refresh=True):
         """Update the Wireshark OUI database to the latest version.
 
         Args:
@@ -151,6 +152,26 @@ class MacParser(object):
             raise URLError("Failed downloading database: {0}".format(err))
 
         response.close()
+        if not wfa_url:
+            wfa_url = self.WFA_URL
+            
+        # Append WFA to new database
+        try:
+            response = urlopen(wfa_url)
+        except URLError:
+            raise URLError("Failed downloading WFA database")
+
+        # Parse the response
+        if response.code is 200:
+            with open(manuf_name, "ab") as write_file:
+                write_file.write(response.read())
+            if refresh:
+                self.refresh(manuf_name)
+        else:
+            err = "{0} {1}".format(response.code, response.msg)
+            raise URLError("Failed downloading database: {0}".format(err))
+
+        response.close()                       
 
     def search(self, mac, maximum=1):
         """Search for multiple Vendor tuples possibly matching a MAC address.


### PR DESCRIPTION
Wireshark separated OUI and WFA into separate files. This will merge the two files when manuf does the update request.

Wireshark commit:

Put the well-known addresses into a separate file from OUIs

Having two distinct logical concepts (OUI and Well Known Address)
concatenated to a single "manuf" file is needlessly obfuscating
the WKA feature.

Have a distinct "wka" file instead and just skip the cat.

Change-Id: I46f53b0015a37331d65f8cfac7cbbd499dd0c5b8
Reviewed-on: https://code.wireshark.org/review/22742
Petri-Dish: Michael Mann mmann78@netscape.net
Tested-by: Petri Dish Buildbot buildbot-no-reply@wireshark.org
Reviewed-by: Michael Mann mmann78@netscape.net